### PR TITLE
flooding loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ node dist/index.js
 ```
 
 ## Details of the concept
-Implemented script does the following:
+Implemented script repeats infinitely long the following steps:
 - Derives temporary accounts from Alice account
 - Setups these accounts, transfering existential deposit to them
 - Generates bunch of transactions, transfers from temporary accounts to Alice
@@ -34,3 +34,4 @@ Script may also try to wait for all sent transactions' finalization (see corresp
 - `finalization` - boolean flag, if true, script should wait for all transactions finalization, default is false
 - `finalization_timeout` - amount of time to wait in every attempt, default is 20000 (in ms); screen makes several attempts, so the total waiting time is finalization_timeout * finalization_attempts
 - `finalization_attempts` - amount of waiting attempts, default is 5
+- `only_flooding` - boolean flag, if true, script will not compute overall statistics after submitting transactions but instead immediately attempts to start a new round of flooding

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,9 +130,9 @@ async function collectStats(
     initialTime: Date,
     measureFinalisation: boolean,
     finalisationTimeout: number,
-    finalisedTxs: Uint16Array,
     totalTransactions: number,
     finalisationAttempts: number,
+    finalisedTxs: Uint16Array,
     finalisationTime: Uint32Array
 ) {
     let finalTime = new Date();
@@ -144,7 +144,7 @@ async function collectStats(
     console.log(`latest block: ${latest_block.date}`);
     console.log(`initial time: ${initialTime}`);
     let prunedFlag = false;
-    for (; latest_block.date > initialTime;) {
+    while (latest_block.date > initialTime) {
         try {
             latest_block = await getBlockStats(api, latest_block.parent);
         } catch (err) {
@@ -165,9 +165,8 @@ async function collectStats(
     console.log(`TPS from ${total_blocks} blocks: ${tps}`);
 
     if (measureFinalisation && !prunedFlag) {
-        let break_condition = false;
         let attempt = 0;
-        while (!break_condition) {
+        while (true) {
             console.log(`Wait ${finalisationTimeout} ms for transactions finalisation, attempt ${attempt} out of ${finalisationAttempts}`);
             let finalized = Atomics.load(finalisedTxs, 0)
             console.log(`Finalized ${finalized} out of ${totalTransactions}`);
@@ -176,12 +175,12 @@ async function collectStats(
             if (Atomics.load(finalisedTxs, 0) < totalTransactions) {
                 if (attempt == finalisationAttempts) {
                     // time limit reached
-                    break_condition = true;
+                    break;
                 } else {
                     attempt++;
                 }
             } else {
-                break_condition = true;
+                break;
             }
         }
         console.log(`Finalized ${Atomics.load(finalisedTxs, 0)} out of ${totalTransactions} transactions, finalization time was ${Atomics.load(finalisationTime, 0)}`);
@@ -291,7 +290,7 @@ async function run() {
             if (ONLY_FLOODING) {
                 return resolve();
             }
-            await collectStats(api, initialTime, MEASURE_FINALISATION, FINALISATION_TIMEOUT, finalisedTxs, TOTAL_TRANSACTIONS, FINALISATION_ATTEMPTS, finalisationTime);
+            await collectStats(api, initialTime, MEASURE_FINALISATION, FINALISATION_TIMEOUT, TOTAL_TRANSACTIONS, FINALISATION_ATTEMPTS, finalisedTxs, finalisationTime);
             return resolve();
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ async function run() {
     let MEASURE_FINALISATION = argv.finalization ? argv.finalization : false;
     let FINALISATION_TIMEOUT = argv.finalization_timeout ? argv.finalization_timeout : 20000; // 20 seconds
     let FINALISATION_ATTEMPTS = argv.finalization_attempts ? argv.finalization_attempts : 5;
+    let ONLY_FLOODING = argv.only_flooding ? argv.only_flooding : false;
 
     let provider = new WsProvider(WS_URL);
 
@@ -193,6 +194,9 @@ async function run() {
                     console.log(`${errors.length}/${TRANSACTION_PER_BATCH} errors sending transactions`);
                 }
             }
+            if (ONLY_FLOODING) {
+                return resolve();
+            }
 
             let finalTime = new Date();
             let diff = finalTime.getTime() - initialTime.getTime();
@@ -246,7 +250,7 @@ async function run() {
                 console.log(`Finalized ${Atomics.load(finalisedTxs, 0)} out of ${TOTAL_TRANSACTIONS} transactions, finalization time was ${Atomics.load(finalisationTime, 0)}`);
             }
 
-            resolve();
+            return resolve();
         });
 
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,6 @@ async function run() {
             `Alice -> ${receiverSeed} (${keypair.address}) ${initialBalance}`
         );
         await transfer.signAndSend(aliceKeyPair, { nonce: aliceNonce }, ({ status }) => {
-            console.log(`transaction's status: ${status}`);
             if (status.isFinalized) {
                 finalized_transactions++;
             }
@@ -137,9 +136,9 @@ async function run() {
         console.log(`Done pregenerating transactions (${sanityCounter}).`);
 
         // wait for the previous batch before you start a new one
-        console.log("Awaiting previous batches to finish...");
+        console.log("Awaiting previous batch to finish...");
         await submit_promise;
-        console.log("Previous batches finished");
+        console.log("Previous batch finished");
 
         submit_promise = new Promise(async resolve => {
             let nextTime = new Date().getTime();
@@ -167,7 +166,6 @@ async function run() {
                             new Promise<number>(async resolve => {
                                 let transaction = thread_payloads[threadNo][batchNo][transactionNo];
                                 resolve(await transaction.send(({ status }) => {
-                                    console.log(`batch transaction's status: ${status}`);
                                     if (status.isFinalized) {
                                         let finalisationTimeCurrent = new Date().getTime() - initialTime.getTime();
                                         while (true) {


### PR DESCRIPTION
- fixed possible "synchronization" bug in the original codebase
- new way of calculating of the initial balance for seeded accounts
- flooding transactions in an infinite loop: creat batch (while previous transactions are probably still being send) -> await previous batch -> (submit txs in a separate thread) -> creat new batch -> ...
- new command line parameter that indicates whether we should skip calculations of runtime statistics (just flooding): --only_flooding=true
